### PR TITLE
configuracion resilience4j yml .properties

### DIFF
--- a/springboot-servicio-item/src/main/resources/application.properties
+++ b/springboot-servicio-item/src/main/resources/application.properties
@@ -8,3 +8,16 @@ eureka.client.service-url.defaultZone=http://localhost:8761/eureka
 #hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds: 20000
 #ribbon.ConnectTimeout: 3000
 #ribbon.ReadTimeout: 10000
+
+
+
+#    resilience4j.circuitbreaker.configs.defecto.sliding-window-size=6
+#    resilience4j.circuitbreaker.configs.defecto.failure-rate-threshold=50
+#    resilience4j.circuitbreaker.configs.defecto.wait-duration-in-open-state=20s
+#    resilience4j.circuitbreaker.configs.defecto.permitted-number-of-calls-in-half-open-state=4
+#    resilience4j.circuitbreaker.configs.defecto.slow-call-rate-threshold=50
+#    resilience4j.circuitbreaker.configs.defecto.slow-call-duration-threshold=2s
+#    resilience4j.circuitbreaker.instances.items.base-config=defecto
+     
+#    resilience4j.timelimiter.configs.defecto.timeout-duration=2s
+#    resilience4j.timelimiter.instances.items.base-config=defecto

--- a/springboot-servicio-item/src/main/resources/application.yml
+++ b/springboot-servicio-item/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+resilience4j:
+  circuitbreaker:
+    configs:
+      defecto:
+        sliding-window-size: 6
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 20s
+        permitted-number-of-calls-in-half-open-state: 4
+        slow-call-rate-threshold: 50
+        slow-call-duration-threshold: 2s
+    instances:
+      items:
+        base-config: defecto
+  timelimiter:
+    configs:
+      defecto:
+        timeout-duration: 6s
+    instances:
+      items:
+        base-config: defecto          
+    


### PR DESCRIPTION
Configuración en application.properties:

    resilience4j.circuitbreaker.configs.defecto.sliding-window-size=6
    resilience4j.circuitbreaker.configs.defecto.failure-rate-threshold=50
    resilience4j.circuitbreaker.configs.defecto.wait-duration-in-open-state=20s
    resilience4j.circuitbreaker.configs.defecto.permitted-number-of-calls-in-half-open-state=4
    resilience4j.circuitbreaker.configs.defecto.slow-call-rate-threshold=50
    resilience4j.circuitbreaker.configs.defecto.slow-call-duration-threshold=2s
    resilience4j.circuitbreaker.instances.items.base-config=defecto
     
    resilience4j.timelimiter.configs.defecto.timeout-duration=2s
    resilience4j.timelimiter.instances.items.base-config=defecto


Configuración en application.yml:

    resilience4j:
      circuitbreaker:
        configs:
          defecto:
            sliding-window-size: 6
            failure-rate-threshold: 50
            wait-duration-in-open-state: 20s
            permitted-number-of-calls-in-half-open-state: 4
            slow-call-rate-threshold: 50
            slow-call-duration-threshold: 2s
        instances:
          items:
            base-config: defecto
      timelimiter:
        configs:
          defecto:
            timeout-duration: 2s
        instances:
          items:
            base-config: defecto