### PR TITLE
se configura gateway con resilience4j

### DIFF
--- a/springboot-servicio-gateway-server/pom.xml
+++ b/springboot-servicio-gateway-server/pom.xml
@@ -38,6 +38,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/springboot-servicio-gateway-server/src/main/resources/application.yml
+++ b/springboot-servicio-gateway-server/src/main/resources/application.yml
@@ -1,3 +1,24 @@
+resilience4j:
+  circuitbreaker:
+    configs:
+      defecto:
+        sliding-window-size: 6
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 20s
+        permitted-number-of-calls-in-half-open-state: 4
+        slow-call-rate-threshold: 50
+        slow-call-duration-threshold: 2s
+    instances:
+      productos:
+        base-config: defecto
+  timelimiter:
+    configs:
+      defecto:
+        timeout-duration: 2s
+    instances:
+      productos:
+        base-config: defecto    
+        
 spring:
   cloud:
     gateway:
@@ -7,6 +28,11 @@ spring:
         predicates:
           - Path=/api/productos/**
         filters:
+          - name: CircuitBreaker
+            args: 
+              name: productos
+              statusCodes: 500, 404
+              fallbackUri: forward:/api/items/ver/9/cantidad/5
           - StripPrefix=2
           - name: EjemploCookie
             args:


### PR DESCRIPTION
Solo en caso de que les de algún error relacionado al filtro EjemploGlobalFilter en el ejemplo del video anterior de Spring Cloud Gateway con Resilience4J.

La solución es modificar el orden dejándolo en 10 o 100:

    	@Override
    	public int getOrder() {
    		return 10;
    	}